### PR TITLE
Sync navbar links with AndrewFasano.com

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -342,10 +342,9 @@
             </button>
             <ul class="navbar-nav" id="navbar-nav">
                 <li><a href="https://andrewfasano.com#about-me">About</a></li>
-                <li><a href="https://andrewfasano.com#news">News</a></li>
+                <li><a href="https://andrewfasano.com#recently">Recently</a></li>
                 <li><a href="https://andrewfasano.com#projects">Projects</a></li>
                 <li><a href="https://andrewfasano.com#talks">Talks</a></li>
-                <li><a href="https://andrewfasano.com#awards">Awards</a></li>
                 <li><a href="/">Security Blog</a></li>
             </ul>
         </div>


### PR DESCRIPTION
Rename 'News' to 'Recently' (#news → #recently) and remove the
'Awards' link so the blog navbar matches the public site.